### PR TITLE
fix: typos in documentation files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ This ensures consistency and enables automated tooling.
 
 ### Submit a Pull Request
 
-1. [Open a Pull Request](https://github.com/kkrt-labs/go-utils/compare) from your branch targetting the `main` branch.
+1. [Open a Pull Request](https://github.com/kkrt-labs/go-utils/compare) from your branch targeting the `main` branch.
   - Provide a clear title respecting [gitmoji](https://github.com/carloscuesta/gitmoji) message convention
   - Provide a detailed description of the change
   - Reference associated issues resolved by the Pull Request.

--- a/tag/set.go
+++ b/tag/set.go
@@ -2,7 +2,7 @@ package tag
 
 var EmptySet = Set{}
 
-// Set reprensents a immutable set of
+// Set represents a immutable set of
 type Set []*Tag
 
 // WithTags returns a new set with the given tags added to the set. If a tag with the same key already exists in the set,


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `targetting` to `targeting`
Corrected `reprensents` to `represents`

Please review the changes and let me know if any additional changes are needed.