### PR TITLE
🐛 Fix reflection logic in Val function for proper pointer dereferencing

### DIFF
--- a/common/ptr.go
+++ b/common/ptr.go
@@ -11,7 +11,7 @@ func Ptr[T any](v T) *T {
 // If the pointer is nil, it returns the zero value of the type.
 func Val[T any](v *T) T {
 	if v == nil {
-		return reflect.Zero(reflect.TypeOf(v).Elem()).Interface().(T)
+		return reflect.Zero(reflect.TypeOf(*v)).Interface().(T)
 	}
 	return *v
 }


### PR DESCRIPTION
📝 Description
The change involves fixing a bug in the Val function within the common/ptr.go file. The original implementation incorrectly used reflect.TypeOf(v).Elem() to obtain the type of the value a pointer points to. This has been updated to reflect.TypeOf(*v) to properly dereference the pointer and get the correct type.

✅ Solved Issues
Resolves potential bug in pointer reflection logic.

🔄 Change
 ✨ New feature (e.g. API route, major perf improvement...)

 🐛 Bug fix

 🧹 Chore (e.g. package upgrades, configuration change, refactor, small perf improvement, typos...)

 🧪 Tests

 🏭 DevOps (e.g. CI-CD, development environment upgrade, security upgrade, automation addition...)

 📚 Documentation

 💥 Breaking Change

💥 Breaking Change (if applicable)
This PR does not introduce a breaking change.

📋 Checklist
 I have added tests to cover my changes, if applicable.
 I have updated relevant documentation for my changes.
 I have included references to issues resolved by this Pull Request
 I have set a Pull Request title that respects [gitmoji](https://gitmoji.dev/)
 I have set a Pull Request's label to one of type.feat,type.fix,type.chore,type.test,type.docs,type.devops
 I have set a Pull Request's label to one of breaking-change or non-breaking-change
 I have documented breaking changes and migration path, if applicable
📓 Additional Notes
The change in common/ptr.go resolves an issue with dereferencing pointers using reflection. The original code used reflect.TypeOf(v).Elem(), which was incorrect as v is a pointer. The updated code uses reflect.TypeOf(*v) to properly dereference the pointer.
<!-- Include any additional context, considerations, or dependencies relevant to this pull request. -->
