### PR TITLE
`type.docs`: correct spelling in comment for clarity `non-breaking-change`

### DIFF
--- a/jsonrpc/websocket/client.go
+++ b/jsonrpc/websocket/client.go
@@ -93,7 +93,7 @@ func (c *Client) call(ctx context.Context, r *jsonrpc.Request, res interface{}) 
 	}
 	defer close(op.result)
 
-	// We need to lock the inflights map as we are accessing it concurrenltly
+	// We need to lock the inflights map as we are accessing it concurrently
 	c.mux.Lock()
 	c.inflights[r.ID] = op
 	c.mux.Unlock()


### PR DESCRIPTION
## 📝 Description

<img width="436" alt="Снимок экрана 2025-03-05 в 19 22 35" src="https://github.com/user-attachments/assets/d623996d-ea8d-4f93-b057-8eeff6d99404" />

I’ve corrected the word "concurrenltly" to "concurrently" in the comment.

## ✅ Solved Issues

This ensures the text is accurate and maintains consistency in the code.

## 🔄 Change

- [ ] ✨ New feature (e.g. API route, major perf improvement...)
- [ ] 🐛 Bug fix
- [x] 🧹 Chore (e.g. package upgrades, configuration change, refactor, small perf improvement, typos...)
- [ ] 🧪 Tests
- [ ] 🏭 DevOps (e.g. CI-CD, development environment upgrade, security upgrade, automation addition...)
- [x] 📚 Documentation


- [ ] 💥 Breaking Change

## 💥 Breaking Change (if applicable)


## 📋 Checklist


- [x] I have added tests to cover my changes, if applicable.
- [x] I have updated relevant documentation for my changes.
- [x] I have included references to issues resolved by this Pull Request
- [ ] I have set a Pull Request title that respects [gitmoji](https://gitmoji.dev/)
- [x] I have set a Pull Request's label to one of `type.feat`,`type.fix`,`type.chore`,`type.test`,`type.docs`,`type.devops`
- [x] I have set a Pull Request's label to one of `breaking-change` or `non-breaking-change`
- [ ] I have documented breaking changes and migration path, if applicable

## 📓 Additional Notes
