### PR TITLE
Fix typos in HEALTHZ environment variable names

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -19,9 +19,9 @@ The application supports the following configuration flags:
 |------|---------------------|-------------|---------------|
 | `--healthz-ep-addr` | `HEALTHZ_ENTRYPOINT_ADDR` | Health check entrypoint address | `:8081` |
 | `--healthz-ep-keep-alive` | `HEALTHZ_ENTRYPOINT_NET_KEEP_ALIVE` | Health check entrypoint keep alive | `0` |
-| `--healthz-ep-http-read-timeout` | `HEALTHZ_NTRYPOINT_HTTP_READ_TIMEOUT` | Health entrypoint maximum duration for reading an entire request including the body (zero means no timeout) | `30s` |
-| `--healthz-ep-http-read-header-timeout` | `HEALTHZ_NTRYPOINT_HTTP_READ_HEADER_TIMEOUT` | Health entrypoint maximum duration for reading request headers (zero uses the value of read timeout) | `30s` |
-| `--healthz-ep-http-write-timeout` | `HEALTHZ_NTRYPOINT_HTTP_WRITE_TIMEOUT` | Health entrypoint maximum duration for writing the response (zero means no timeout) | `30s` |
-| `--healthz-ep-http-idle-timeout` | `HEALTHZ_NTRYPOINT_HTTP_IDLE_TIMEOUT` | Health entrypoint maximum amount of time to wait for the next request when keep-alives are enabled (zero uses the value of read timeout) | `30s` |
+| `--healthz-ep-http-read-timeout` | `HEALTHZ_ENTRYPOINT_HTTP_READ_TIMEOUT` | Health entrypoint maximum duration for reading an entire request including the body (zero means no timeout) | `30s` |
+| `--healthz-ep-http-read-header-timeout` | `HEALTHZ_ENTRYPOINT_HTTP_READ_HEADER_TIMEOUT` | Health entrypoint maximum duration for reading request headers (zero uses the value of read timeout) | `30s` |
+| `--healthz-ep-http-write-timeout` | `HEALTHZ_ENTRYPOINT_HTTP_WRITE_TIMEOUT` | Health entrypoint maximum duration for writing the response (zero means no timeout) | `30s` |
+| `--healthz-ep-http-idle-timeout` | `HEALTHZ_ENTRYPOINT_HTTP_IDLE_TIMEOUT` | Health entrypoint maximum amount of time to wait for the next request when keep-alives are enabled (zero uses the value of read timeout) | `30s` |
 
 All configuration flags can be set via command-line arguments, environment variables, or through a configuration file. The application uses [Viper](https://github.com/spf13/viper) for configuration management, which supports multiple configuration formats.


### PR DESCRIPTION
## 📝 Description

Squashed the sneaky "E" escape attempts in our HEALTHZ environment variables. These rogue variables were operating undercover as "NTRYPOINT" instead of "ENTRYPOINT", causing potential configuration chaos. All fugitive letters have been apprehended and returned to their rightful positions in the documentation.

- [ ] ✨ New feature (e.g. API route, major perf improvement...)
- [x] 🐛 Bug fix
- [ ] 🧹 Chore (e.g. package upgrades, configuration change, refactor, small perf improvement, typos...)
- [ ] 🧪 Tests
- [ ] 🏭 DevOps (e.g. CI-CD, development environment upgrade, security upgrade, automation addition...)
- [x] 📚 Documentation
