### PR TITLE
Update golangci/golangci-lint-action from v6 to v8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Run linting tests
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: ${{ env.GOLANGCI_VERSION }}
           args: -v --timeout 3m0s


### PR DESCRIPTION
Old version: golangci/golangci-lint-action@v6
New version: golangci/golangci-lint-action@v8

Official release notes: https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0